### PR TITLE
Refactor bot to use ORM database sessions

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -26,3 +26,13 @@ def search_images_by_tag(name: str):
 def search_images_by_character(name: str):
     """Найти изображения по персонажу."""
     return crud.search_by_character(name)
+
+
+def get_image(image_id: int):
+    """Получить изображение по ID."""
+    return crud.get_image(image_id)
+
+
+def get_all_images():
+    """Получить все изображения."""
+    return crud.get_all_images()

--- a/db/crud.py
+++ b/db/crud.py
@@ -101,3 +101,33 @@ def search_by_character(character_name: str):
             .filter(models.Character.name.ilike(f"%{character_name}%"))
             .all()
         )
+
+
+def get_image(image_id: int):
+    """Получить изображение по ID вместе с его связями."""
+    with get_session() as session:
+        return (
+            session.query(models.Image)
+            .options(
+                selectinload(models.Image.authors),
+                selectinload(models.Image.tags),
+                selectinload(models.Image.characters),
+            )
+            .filter(models.Image.id == image_id)
+            .first()
+        )
+
+
+def get_all_images():
+    """Получить все изображения с отсортированными связями."""
+    with get_session() as session:
+        return (
+            session.query(models.Image)
+            .options(
+                selectinload(models.Image.authors),
+                selectinload(models.Image.tags),
+                selectinload(models.Image.characters),
+            )
+            .order_by(models.Image.id)
+            .all()
+        )


### PR DESCRIPTION
## Summary
- replace JSON-based PhotoDatabase with ORM handlers
- add CRUD helpers for fetching images and integrate into bot commands
- initialize database before launching the bot

## Testing
- `python -m py_compile db/crud.py bot/handlers.py main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a2d460f488321bcf96e5bc3afe697