### PR TITLE
Use environment variable for bot token

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@
 git clone https://github.com/ваш-username/image-tagbot.git
 cd image-tagbot
 ```
+2. Установите токен бота в переменную окружения `BOT_TOKEN`:
+```bash
+export BOT_TOKEN="ВАШ_ТОКЕН"
+```

--- a/main.py
+++ b/main.py
@@ -12,7 +12,9 @@ from telegram.ext import (
 from bot import handlers
 from db.database import init_db
 
-TOKEN = 'YOUR_BOT_ID'
+TOKEN = os.getenv("BOT_TOKEN")
+if TOKEN is None:
+    raise ValueError("Переменная окружения BOT_TOKEN не установлена")
 
 # Определяем состояния для ConversationHandler
 ADD_PHOTO, ADD_AUTHORS, ADD_TAGS, ADD_CHARACTERS = range(4)


### PR DESCRIPTION
## Summary
- Load Telegram token from `BOT_TOKEN` environment variable and fail if unset
- Document how to set `BOT_TOKEN` in the environment

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a316acb6c83218a216f16d3d8ac5e