### PR TITLE
Добавлены тесты для CRUD и классификатора

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,64 @@
+import shutil
+from pathlib import Path
+
+import classifier
+
+
+def test_classify_image_extension_fallback(monkeypatch, tmp_path):
+    dummy = tmp_path / "image.png"
+    dummy.touch()
+    monkeypatch.setattr(classifier, "_load_classifier", lambda: (None, None, None))
+
+    result = classifier.classify_image(str(dummy))
+    assert result == "anime"
+
+
+def test_move_to_category_moves_file(tmp_path, monkeypatch):
+    src = tmp_path / "pic.jpg"
+    src.write_text("data")
+    monkeypatch.chdir(tmp_path)
+
+    moved = {}
+
+    def fake_move(src_path, dst_path):
+        moved["src"] = src_path
+        moved["dst"] = dst_path
+
+    monkeypatch.setattr(shutil, "move", fake_move)
+
+    dest = classifier.move_to_category(str(src), "photo")
+    expected = str(Path("data/photos/pic.jpg"))
+    assert dest == expected
+    assert moved["src"] == str(src)
+    assert str(moved["dst"]) == expected
+
+
+def test_prepare_image_calls_classify_and_move(monkeypatch):
+    calls = {}
+
+    def fake_classify(path):
+        calls["classify"] = path
+        return "anime"
+
+    def fake_move(path, image_type):
+        calls["move"] = (path, image_type)
+        return f"/new/{path}"
+
+    class DummyTagger:
+        pass
+
+    def fake_get_tagger(image_type):
+        calls["tagger"] = image_type
+        return DummyTagger()
+
+    monkeypatch.setattr(classifier, "classify_image", fake_classify)
+    monkeypatch.setattr(classifier, "move_to_category", fake_move)
+    monkeypatch.setattr(classifier, "get_tagger", fake_get_tagger)
+
+    new_path, tagger = classifier.prepare_image("old/file.png")
+
+    assert new_path == "/new/old/file.png"
+    assert isinstance(tagger, DummyTagger)
+    assert calls["classify"] == "old/file.png"
+    assert calls["move"] == ("old/file.png", "anime")
+    assert calls["tagger"] == "anime"

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,0 +1,48 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import db.database as database
+import db.crud as crud
+
+
+@pytest.fixture(autouse=True)
+def in_memory_db(monkeypatch):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    database.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(database, "SessionLocal", TestingSessionLocal)
+    monkeypatch.setattr(crud, "SessionLocal", TestingSessionLocal)
+    yield
+
+
+def test_add_and_search_tags():
+    image = crud.add_image("file1.png", tags=["cat", "cute"])
+    assert sorted(t.name for t in image.tags) == ["cat", "cute"]
+
+    results = crud.search_by_tag("cat")
+    assert len(results) == 1
+    assert results[0].file_path == "file1.png"
+
+
+def test_add_tags_updates_image():
+    image = crud.add_image("file2.png", tags=["old"])
+    crud.add_tags(image.id, ["new"])
+
+    updated = crud.get_image(image.id)
+    assert sorted(t.name for t in updated.tags) == ["new", "old"]
+
+    results = crud.search_by_tag("new")
+    assert len(results) == 1 and results[0].id == image.id


### PR DESCRIPTION
## Summary
- Добавлены тесты для CRUD: добавление, поиск и обновление тегов
- Добавлены тесты классификатора с mock'ами для классификации и перемещения файлов
- Настроен запуск тестов через pytest

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a62d1543083219d8ac6cec706e505